### PR TITLE
Add GitHub Community Spain and fix the nav.

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,8 +64,8 @@
 
                     <ul class="s-header__menu-links">
                         <li class="current"><a href="#intro" class="smoothscroll">Intro</a></li>
-                        <li><a href="#communities" class="smoothscroll">Comunidades</a></li>
                         <li><a href="#calendar" class="smoothscroll">Calendario</a></li>
+                        <li><a href="#communities" class="smoothscroll">Comunidades</a></li>
                     </ul> <!-- s-header__menu-links -->
 
                     <ul class="s-header__social">
@@ -120,7 +120,7 @@
 
             <!-- communities
             ----------------------------------------------- -->
-            <section id="communities" class="s-folio target-section">
+            <section class="s-folio target-section">
 
                 <!-- calendar
                 -------------------------------------------- -->
@@ -145,7 +145,7 @@
                     </div> <!-- end column -->
                 </div> <!-- end calendar -->
 
-                <div class="row section-header light-on-dark" data-num="">
+                <div id="communities" class="row section-header light-on-dark" data-num="">
                     <h3 class="column lg-12 section-header__pretitle text-pretitle">Comunidades</h3>
                     <div class="column lg-6 stack-on-1100 section-header__primary">
                         <h2 class="title text-display-1">

--- a/index.html
+++ b/index.html
@@ -291,6 +291,19 @@
                                 </a>
                             </article> <!-- entry -->
 
+                            <article class="brick entry">
+                                <a href="#modal-10" class="entry__link">
+                                    <div class="entry__thumb">
+                                        <img src="https://pbs.twimg.com/profile_images/1707693686392274945/LN8WgzUy_400x400.png"
+                                            alt="Logo de GitHub Community Spain">
+                                    </div>
+                                    <div class="entry__info">
+                                        <div class="entry__cat">Software development</div>
+                                        <h4 class="entry__title">GitHub Community Spain</h4>
+                                    </div>
+                                </a>
+                            </article> <!-- entry -->
+
                         </div> <!-- end bricks-wrapper -->
                     </div> <!-- end masonry -->
                 </div> <!-- end bricks -->
@@ -540,6 +553,38 @@
                         </div>
 
                         <a href="https://azuremalaga.eventbrite.com" class="modal-popup__details">Eventbrite group</a>
+                    </div>
+                </div> <!-- end modal -->
+
+                <!-- ...existing code... -->
+                <div id="modal-10" hidden>
+                    <div class="modal-popup">
+                        <img src="https://yt3.googleusercontent.com/XEEmzrjeXK_fQuLS6Plh2ZE1NiRRKhZggwTzA6qaxA-XwJujFSOZ0sPMxFQlx05Lum9S20Ieg1o=w1707-fcrop64=1,00005a57ffffa5a8-k-c0xffffffff-no-nd-rj" alt="Logo de GitHub Community Spain">
+
+                        <div class="modal-popup__desc">
+                            <h5>GitHub Community Spain</h5>
+                            <p> GitHub Community Spain es una comunidad dedicada a compartir, aprender y colaborar en el desarrollo de software. 
+                                Fomentamos la cultura del aprendizaje continuo, la curiosidad y la experimentación, animando a nuestros miembros a enseñar y aprender. 
+                                Somos altruistas, abiertos y participativos, basados en GitHub para gestionar proyectos y compartir código. 
+                                Organizamos meetups y participamos en eventos por toda España, creando un espacio inclusivo para expresarnos, inspirarnos y crecer juntos.</p>
+                            <p>Encuéntranos en:
+                                <a href="https://github.com/ghspain">GitHub</a>,
+                                <a href="https://www.linkedin.com/company/ghspain">LinkedIn</a>,
+                                <a href="https://www.youtube.com/@GitHubCommunitySpain">YouTube</a>,
+                                <a href="https://x.com/GithubCommSpain">X (Twitter)</a>,
+                                <a href="https://www.meetup.com/ghspain/">MeetUp</a> y nuestra
+                                <a href="https://githubcommunity.es">web</a>.
+                            </p>
+
+                            <ul class="modal-popup__cat">
+                                <li>Software Development</li>
+                                <li>DevOps</li>
+                                <li>GitHub</li>
+                                <li>Open Source</li>
+                            </ul>
+                        </div>
+
+                        <a href="https://www.meetup.com/ghspain/" class="modal-popup__details">Meetup</a>
                     </div>
                 </div> <!-- end modal -->
 

--- a/index.html
+++ b/index.html
@@ -120,7 +120,7 @@
 
             <!-- calendar
             ----------------------------------------------- -->
-            <section id="calendar" class="s-folio target-section">
+            <section id="calendar" class="s-folio target-section" style="padding-top: 2rem;">
 
                 <div class="s-clients row">
                     <div class="column lg-12">
@@ -147,7 +147,7 @@
 
             <!-- communities
             ----------------------------------------------- -->
-            <section id="communities" class="s-folio target-section">
+            <section id="communities" class="s-folio target-section" style="padding-top: 2rem;">
 
                 <div class="row section-header light-on-dark" data-num="">
                     <h3 class="column lg-12 section-header__pretitle text-pretitle">Comunidades</h3>

--- a/index.html
+++ b/index.html
@@ -118,13 +118,11 @@
 
             </section> <!-- end s-intro -->
 
-            <!-- communities
+            <!-- calendar
             ----------------------------------------------- -->
-            <section class="s-folio target-section">
+            <section id="calendar" class="s-folio target-section">
 
-                <!-- calendar
-                -------------------------------------------- -->
-                <div id="calendar" class="s-clients row">
+                <div class="s-clients row">
                     <div class="column lg-12">
 
                         <div class="row section-header">
@@ -143,9 +141,15 @@
                             </div>
                         </div>
                     </div> <!-- end column -->
-                </div> <!-- end calendar -->
+                </div> <!-- end s-clients -->
 
-                <div id="communities" class="row section-header light-on-dark" data-num="">
+            </section> <!-- end s-folio (calendar) -->
+
+            <!-- communities
+            ----------------------------------------------- -->
+            <section id="communities" class="s-folio target-section">
+
+                <div class="row section-header light-on-dark" data-num="">
                     <h3 class="column lg-12 section-header__pretitle text-pretitle">Comunidades</h3>
                     <div class="column lg-6 stack-on-1100 section-header__primary">
                         <h2 class="title text-display-1">


### PR DESCRIPTION
This pull request adds a new featured community, GitHub Community Spain, to the main page. The update includes both a new entry in the community grid and a detailed modal popup with information and links about the group.

**New community addition:**

* Added a new `article` block for GitHub Community Spain in the main grid, including its logo, category, and title.
<img width="1895" height="912" alt="image" src="https://github.com/user-attachments/assets/ae68e994-9876-4670-bec4-b334437802f1" />

**Modal popup for community details:**

* Introduced a new modal (`modal-10`) with a detailed description of GitHub Community Spain, including its mission, activities, and links to GitHub, LinkedIn, YouTube, X (Twitter), Meetup, and its website. The modal also lists relevant categories (Software Development, DevOps, GitHub, Open Source) and includes a direct link to the Meetup page.
<img width="1898" height="919" alt="image" src="https://github.com/user-attachments/assets/2479b3a2-12fc-4072-bbbc-128c4fb7a13d" />

**Nav fixes:**

In addition, while checking if the website was correct, I noticed that the nav was not functional when you clicked on "Comunidades". I have moved the id to the correct section. The order of the sections in the nav was changed to match the order on the website.

Since the highlighting was not working properly, I used different sections, instead of leaving the calendar inside the "Comunidades" section as it was.
